### PR TITLE
add !appengine build tags to assembly files

### DIFF
--- a/hash128_amd64.s
+++ b/hash128_amd64.s
@@ -1,3 +1,5 @@
+// +build amd64,!appengine
+
 // This is a translation of the gcc output of FloodyBerry's pure-C public
 // domain siphash implementation at https://github.com/floodyberry/siphash
 

--- a/hash_amd64.s
+++ b/hash_amd64.s
@@ -1,3 +1,5 @@
+// +build amd64,!appengine
+
 // This is a translation of the gcc output of FloodyBerry's pure-C public
 // domain siphash implementation at https://github.com/floodyberry/siphash
 


### PR DESCRIPTION
Without them, this package fails to build with -tags 'appengine' due to
duplicate symbols.