### PR TITLE
amd64 implementation of block digest

### DIFF
--- a/block.go
+++ b/block.go
@@ -1,0 +1,58 @@
+// +build !amd64 appengine gccgo
+
+package siphash
+
+func blocks(d *digest, p []uint8) {
+	v0, v1, v2, v3 := d.v0, d.v1, d.v2, d.v3
+
+	for len(p) >= BlockSize {
+		m := uint64(p[0]) | uint64(p[1])<<8 | uint64(p[2])<<16 | uint64(p[3])<<24 |
+			uint64(p[4])<<32 | uint64(p[5])<<40 | uint64(p[6])<<48 | uint64(p[7])<<56
+
+		v3 ^= m
+
+		// Round 1.
+		v0 += v1
+		v1 = v1<<13 | v1>>(64-13)
+		v1 ^= v0
+		v0 = v0<<32 | v0>>(64-32)
+
+		v2 += v3
+		v3 = v3<<16 | v3>>(64-16)
+		v3 ^= v2
+
+		v0 += v3
+		v3 = v3<<21 | v3>>(64-21)
+		v3 ^= v0
+
+		v2 += v1
+		v1 = v1<<17 | v1>>(64-17)
+		v1 ^= v2
+		v2 = v2<<32 | v2>>(64-32)
+
+		// Round 2.
+		v0 += v1
+		v1 = v1<<13 | v1>>(64-13)
+		v1 ^= v0
+		v0 = v0<<32 | v0>>(64-32)
+
+		v2 += v3
+		v3 = v3<<16 | v3>>(64-16)
+		v3 ^= v2
+
+		v0 += v3
+		v3 = v3<<21 | v3>>(64-21)
+		v3 ^= v0
+
+		v2 += v1
+		v1 = v1<<17 | v1>>(64-17)
+		v1 ^= v2
+		v2 = v2<<32 | v2>>(64-32)
+
+		v0 ^= m
+
+		p = p[BlockSize:]
+	}
+
+	d.v0, d.v1, d.v2, d.v3 = v0, v1, v2, v3
+}

--- a/block_amd64.s
+++ b/block_amd64.s
@@ -1,0 +1,45 @@
+// +build amd64,!appengine,!gccgo
+	
+#define ROUND(v0, v1, v2, v3) \
+	ADDQ v1, v0; \
+	RORQ $51, v1; \
+	ADDQ v3, v2; \
+	XORQ v0, v1; \
+	RORQ $48, v3; \
+	RORQ $32, v0; \
+	XORQ v2, v3; \
+	ADDQ v1, v2; \
+	ADDQ v3, v0; \
+	RORQ $43, v3; \
+	RORQ $47, v1; \
+	XORQ v0, v3; \
+	XORQ v2, v1; \
+	RORQ $32, v2
+
+// blocks(d *digest, data []uint8)
+TEXT ·blocks(SB),4,$0-32
+	MOVQ d+0(FP), BX
+	MOVQ 0(BX), R9		// R9 = v0
+	MOVQ 8(BX), R10		// R10 = v1
+	MOVQ 16(BX), R11	// R11 = v2
+	MOVQ 24(BX), R12	// R12 = v3
+	MOVQ data+8(FP), DI	// DI = *uint64
+	MOVQ data_len+16(FP), SI// SI = nblocks
+	XORL DX, DX		// DX = index (0)
+	SHRQ $3, SI 		// SI /= 8
+body:
+	CMPQ DX, SI
+	JGE  end
+	MOVQ 0(DI)(DX*8), CX	// CX = m
+	XORQ CX, R12
+	ROUND(R9, R10, R11, R12)
+	ROUND(R9, R10, R11, R12)
+	XORQ CX, R9
+	ADDQ $1, DX
+	JMP  body
+end:
+	MOVQ R9, 0(BX)
+	MOVQ R10, 8(BX)
+	MOVQ R11, 16(BX)
+	MOVQ R12, 24(BX)
+	RET

--- a/hash_amd64.s
+++ b/hash_amd64.s
@@ -1,8 +1,7 @@
 // +build amd64,!appengine,!gccgo
 
 // This is a translation of the gcc output of FloodyBerry's pure-C public
-// domain siphash implementation at https://github.com/floodyberry/siphash
-
+// domain siphash implementation at https://github.com/floodyberry/siphash	
 // func Hash(k0, k1 uint64, b []byte) uint64
 TEXT	·Hash(SB),4,$0-48
 	MOVQ	k0+0(FP),CX

--- a/hash_asm.go
+++ b/hash_asm.go
@@ -11,10 +11,17 @@
 
 package siphash
 
+//go:noescape
+
 // Hash returns the 64-bit SipHash-2-4 of the given byte slice with two 64-bit
 // parts of 128-bit key: k0 and k1.
 func Hash(k0, k1 uint64, b []byte) uint64
 
+//go:noescape
+
 // Hash128 returns the 128-bit SipHash-2-4 of the given byte slice with two
 // 64-bit parts of 128-bit key: k0 and k1.
 func Hash128(k0, k1 uint64, b []byte) (uint64, uint64)
+
+//go:noescape
+func blocks(d *digest, p []uint8)

--- a/siphash.go
+++ b/siphash.go
@@ -74,61 +74,6 @@ func (d *digest) Size() int { return d.size }
 
 func (d *digest) BlockSize() int { return BlockSize }
 
-func blocks(d *digest, p []uint8) {
-	v0, v1, v2, v3 := d.v0, d.v1, d.v2, d.v3
-
-	for len(p) >= BlockSize {
-		m := uint64(p[0]) | uint64(p[1])<<8 | uint64(p[2])<<16 | uint64(p[3])<<24 |
-			uint64(p[4])<<32 | uint64(p[5])<<40 | uint64(p[6])<<48 | uint64(p[7])<<56
-
-		v3 ^= m
-
-		// Round 1.
-		v0 += v1
-		v1 = v1<<13 | v1>>(64-13)
-		v1 ^= v0
-		v0 = v0<<32 | v0>>(64-32)
-
-		v2 += v3
-		v3 = v3<<16 | v3>>(64-16)
-		v3 ^= v2
-
-		v0 += v3
-		v3 = v3<<21 | v3>>(64-21)
-		v3 ^= v0
-
-		v2 += v1
-		v1 = v1<<17 | v1>>(64-17)
-		v1 ^= v2
-		v2 = v2<<32 | v2>>(64-32)
-
-		// Round 2.
-		v0 += v1
-		v1 = v1<<13 | v1>>(64-13)
-		v1 ^= v0
-		v0 = v0<<32 | v0>>(64-32)
-
-		v2 += v3
-		v3 = v3<<16 | v3>>(64-16)
-		v3 ^= v2
-
-		v0 += v3
-		v3 = v3<<21 | v3>>(64-21)
-		v3 ^= v0
-
-		v2 += v1
-		v1 = v1<<17 | v1>>(64-17)
-		v1 ^= v2
-		v2 = v2<<32 | v2>>(64-32)
-
-		v0 ^= m
-
-		p = p[BlockSize:]
-	}
-
-	d.v0, d.v1, d.v2, d.v3 = v0, v1, v2, v3
-}
-
 func (d *digest) Write(p []byte) (nn int, err error) {
 	nn = len(p)
 	d.t += uint8(nn)


### PR DESCRIPTION
I have an application that leans pretty heavily on incremental hashing, so this change was a big perf win.

This brings the implementation of `hash.Hash64` up to performance parity with `Hash(...)`.

Also, I marked the slices passed to `Hash` and `Hash128` as `noescape`.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/dchest/siphash/9)
<!-- Reviewable:end -->
