### PR TITLE
fix vet warnings about names of stack variables referenced from asm

### DIFF
--- a/blocks_amd64.s
+++ b/blocks_amd64.s
@@ -1,5 +1,5 @@
 // +build amd64,!appengine,!gccgo
-	
+
 #define ROUND(v0, v1, v2, v3) \
 	ADDQ v1, v0; \
 	RORQ $51, v1; \
@@ -23,8 +23,8 @@ TEXT ·blocks(SB),4,$0-32
 	MOVQ 8(BX), R10		// R10 = v1
 	MOVQ 16(BX), R11	// R11 = v2
 	MOVQ 24(BX), R12	// R12 = v3
-	MOVQ data+8(FP), DI	// DI = *uint64
-	MOVQ data_len+16(FP), SI// SI = nblocks
+	MOVQ p_base+8(FP), DI	// DI = *uint64
+	MOVQ p_len+16(FP), SI	// SI = nblocks
 	XORL DX, DX		// DX = index (0)
 	SHRQ $3, SI 		// SI /= 8
 body:
@@ -84,4 +84,3 @@ TEXT ·finalize(SB),4,$0-16
 	XORQ R11, R9
 	MOVQ R9, ret+8(FP)
 	RET
-

--- a/hash128_amd64.s
+++ b/hash128_amd64.s
@@ -220,7 +220,7 @@ afterSwitch:
 	XORQ	AX,BX
 	XORQ	DX,BX
 	XORQ	CX,BX
-	MOVQ	BX,r0+40(FP)
+	MOVQ	BX,ret+40(FP)
 
 	// Start the second finalization round
 
@@ -287,6 +287,6 @@ afterSwitch:
 	XORQ	AX,BX
 	XORQ	DX,BX
 	XORQ	CX,BX
-	MOVQ	BX,r1+48(FP)
+	MOVQ	BX,ret1+48(FP)
 
 	RET


### PR DESCRIPTION
In `blocks_amd64.s` the change from `data_len` to `p_len` is because the function is declared as:

```Go
func blocks(d *digest, p []uint8)
```

In `hash_asm.go`.

After these changes, `go vet` has nothing left to complain about :)