### PR TITLE
ARM assembler performance improvements

### DIFF
--- a/blocks_arm.s
+++ b/blocks_arm.s
@@ -90,8 +90,7 @@ TEXT ·finalize(SB),NOSPLIT,$4-12
 	RET
 
 // blocks(d *digest, data []uint8)
-TEXT ·blocks(SB),NOSPLIT,$8-16
-	MOVW	R9,sav-8(SP)
+TEXT ·blocks(SB),NOSPLIT,$4-16
 	MOVW	d+0(FP),R8
 	MOVM.IA	(R8),[R0,R1,R2,R3,R4,R5,R6,R7]
 	MOVW	p+4(FP),R9
@@ -112,24 +111,22 @@ blocksloop:
 	BLO	blocksloop
 	MOVW	d+0(FP),R8
 	MOVM.IA [R0,R1,R2,R3,R4,R5,R6,R7],(R8)
-	MOVW	sav-8(SP),R9
 	RET
 blocksunaligned:
-	MOVBU    (R9),R12
-	MOVBU    1(R9),R11
+	MOVBU.P   8(R9),R12
+	MOVBU    -7(R9),R11
 	ORR     R11<<8,R12,R12
-	MOVBU    2(R9),R11
+	MOVBU    -6(R9),R11
 	ORR     R11<<16,R12,R12
-	MOVBU    3(R9),R11
+	MOVBU    -5(R9),R11
 	ORR     R11<<24,R12,R12
-	MOVBU    4(R9),R14
-	MOVBU    5(R9),R11
+	MOVBU    -4(R9),R14
+	MOVBU    -3(R9),R11
 	ORR     R11<<8,R14,R14
-	MOVBU    6(R9),R11
+	MOVBU    -2(R9),R11
 	ORR     R11<<16,R14,R14
-	MOVBU    7(R9),R11
+	MOVBU    -1(R9),R11
 	ORR     R11<<24,R14,R14
-	ADD     $8,R9,R9
 	EOR     R12,R6,R6
 	EOR     R14,R7,R7
 	ROUND()
@@ -140,5 +137,4 @@ blocksunaligned:
 	BLO     blocksunaligned
 	MOVW    d+0(FP),R8
 	MOVM.IA [R0,R1,R2,R3,R4,R5,R6,R7],(R8)
-	MOVW    sav-8(SP),R9
 	RET


### PR DESCRIPTION
This patch improves the throughput of the ARM assembler version of siphash by up to 12.46% (on a Raspberry Pi 4B):

    name               old time/op    new time/op     delta
    Hash8-4               194ns ± 3%      192ns ± 1%     ~     (p=0.017 n=20+17)
    Hash16-4              213ns ± 1%      216ns ± 2%   +1.10%  (p=0.008 n=16+18)
    Hash40-4              286ns ± 2%      285ns ± 2%     ~     (p=0.482 n=20+20)
    Hash64-4              354ns ± 3%      355ns ± 2%     ~     (p=0.637 n=20+19)
    Hash128-4             538ns ± 3%      536ns ± 2%     ~     (p=0.333 n=20+17)
    Hash1K-4             3.12µs ± 2%     3.13µs ± 3%     ~     (p=0.913 n=20+18)
    Hash1Kunaligned-4    3.79µs ± 1%     3.70µs ± 1%   -2.51%  (p=0.000 n=18+18)
    Hash8K-4             23.5µs ± 1%     23.8µs ± 4%     ~     (p=0.045 n=18+20)
    Hash128_8-4           280ns ± 4%      272ns ± 2%   -2.75%  (p=0.000 n=20+18)
    Hash128_16-4          304ns ± 3%      298ns ± 3%   -2.15%  (p=0.000 n=20+20)
    Hash128_40-4          370ns ± 2%      364ns ± 3%   -1.53%  (p=0.001 n=19+20)
    Hash128_64-4          438ns ± 1%      436ns ± 2%     ~     (p=0.027 n=17+20)
    Hash128_128-4         624ns ± 2%      619ns ± 2%     ~     (p=0.026 n=20+20)
    Hash128_1K-4         3.26µs ± 3%     3.20µs ± 1%   -1.85%  (p=0.000 n=20+20)
    Hash128_8K-4         23.9µs ± 2%     23.8µs ± 3%     ~     (p=0.160 n=20+19)
    Full8-4               180ns ± 6%      176ns ± 3%   -2.28%  (p=0.000 n=20+20)
    Full16-4              203ns ± 3%      198ns ± 2%   -2.26%  (p=0.000 n=19+20)
    Full40-4              202ns ± 3%      197ns ± 2%   -2.50%  (p=0.000 n=19+19)
    Full64-4              346ns ± 3%      337ns ± 2%   -2.58%  (p=0.000 n=17+20)
    Full128-4             346ns ± 6%      336ns ± 1%   -2.70%  (p=0.000 n=19+20)
    Full1K-4             3.14µs ± 2%     3.09µs ± 2%   -1.40%  (p=0.003 n=17+18)
    Full1Kunaligned-4    3.84µs ± 3%     3.72µs ± 2%   -3.18%  (p=0.000 n=20+20)
    Full8K-4             24.3µs ± 5%     23.7µs ± 2%   -2.17%  (p=0.001 n=19+20)
    Full128_8-4           503ns ± 8%      462ns ± 5%   -8.07%  (p=0.000 n=20+20)
    Full128_16-4          534ns ± 7%      484ns ± 3%   -9.44%  (p=0.000 n=19+20)
    Full128_40-4          545ns ±11%      484ns ± 3%  -11.21%  (p=0.000 n=20+20)
    Full128_64-4          692ns ±10%      621ns ± 3%  -10.24%  (p=0.000 n=20+18)
    Full128_128-4         685ns ± 7%      623ns ± 4%   -9.09%  (p=0.000 n=19+20)
    Full128_1K-4         3.61µs ± 6%     3.40µs ± 2%   -5.75%  (p=0.000 n=19+20)
    Full128_8K-4         25.6µs ± 9%     24.3µs ± 2%   -4.97%  (p=0.000 n=20+20)

    name               old speed      new speed       delta
    Hash8-4            41.2MB/s ± 3%   41.7MB/s ± 1%     ~     (p=0.025 n=20+17)
    Hash16-4           74.9MB/s ± 1%   74.2MB/s ± 1%   -1.03%  (p=0.005 n=16+18)
    Hash40-4            140MB/s ± 2%    140MB/s ± 2%     ~     (p=0.482 n=20+20)
    Hash64-4            181MB/s ± 3%    181MB/s ± 2%     ~     (p=0.873 n=20+19)
    Hash128-4           238MB/s ± 3%    239MB/s ± 2%     ~     (p=0.464 n=20+17)
    Hash1K-4            328MB/s ± 2%    327MB/s ± 3%     ~     (p=0.937 n=20+18)
    Hash1Kunaligned-4   270MB/s ± 1%    277MB/s ± 1%   +2.57%  (p=0.000 n=18+18)
    Hash8K-4            348MB/s ± 1%    345MB/s ± 4%     ~     (p=0.045 n=18+20)
    Hash128_8-4        28.7MB/s ± 2%   29.4MB/s ± 2%   +2.41%  (p=0.000 n=18+18)
    Hash128_16-4       52.6MB/s ± 3%   53.8MB/s ± 3%   +2.24%  (p=0.000 n=20+20)
    Hash128_40-4        108MB/s ± 2%    110MB/s ± 3%   +1.57%  (p=0.001 n=19+20)
    Hash128_64-4        146MB/s ± 2%    147MB/s ± 2%     ~     (p=0.013 n=18+20)
    Hash128_128-4       205MB/s ± 2%    207MB/s ± 2%     ~     (p=0.028 n=20+20)
    Hash128_1K-4        314MB/s ± 3%    320MB/s ± 1%   +1.87%  (p=0.000 n=20+20)
    Hash128_8K-4        343MB/s ± 2%    345MB/s ± 3%     ~     (p=0.159 n=20+19)
    Full8-4            44.5MB/s ± 6%   45.6MB/s ± 2%   +2.41%  (p=0.000 n=20+20)
    Full16-4           79.0MB/s ± 3%   80.7MB/s ± 2%   +2.20%  (p=0.000 n=19+20)
    Full40-4            118MB/s ± 6%    122MB/s ± 1%   +3.09%  (p=0.000 n=20+16)
    Full64-4            185MB/s ± 3%    190MB/s ± 2%   +2.45%  (p=0.000 n=18+20)
    Full128-4           369MB/s ± 8%    381MB/s ± 1%   +3.20%  (p=0.000 n=20+20)
    Full1K-4            326MB/s ± 2%    331MB/s ± 2%   +1.42%  (p=0.003 n=17+18)
    Full1Kunaligned-4   267MB/s ± 3%    276MB/s ± 2%   +3.28%  (p=0.000 n=20+20)
    Full8K-4            338MB/s ± 5%    345MB/s ± 2%   +2.19%  (p=0.001 n=19+20)
    Full128_8-4        15.9MB/s ± 9%   17.3MB/s ± 5%   +8.61%  (p=0.000 n=20+20)
    Full128_16-4       30.0MB/s ± 7%   33.1MB/s ± 3%  +10.31%  (p=0.000 n=19+20)
    Full128_40-4       44.1MB/s ±10%   49.6MB/s ± 2%  +12.46%  (p=0.000 n=20+20)
    Full128_64-4       92.7MB/s ±10%  103.1MB/s ± 3%  +11.17%  (p=0.000 n=20+18)
    Full128_128-4       187MB/s ± 6%    206MB/s ± 4%   +9.96%  (p=0.000 n=19+20)
    Full128_1K-4        282MB/s ±10%    301MB/s ± 2%   +6.56%  (p=0.000 n=20+20)
    Full128_8K-4        320MB/s ± 8%    336MB/s ± 2%   +5.03%  (p=0.000 n=20+20)