### PR TITLE
Add a go.mod to enable build without $GO111MODULE

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/dchest/siphash
+
+go 1.16


### PR DESCRIPTION
Go 1.16 refuses to `go build` siphash when freshly cloned, because there is no go.mod:

```
$ git clone https://github.com/dchest/siphash.git
Cloning into 'siphash'...
remote: Enumerating objects: 8, done.
remote: Counting objects: 100% (8/8), done.
remote: Compressing objects: 100% (8/8), done.
remote: Total 199 (delta 1), reused 2 (delta 0), pack-reused 191
Receiving objects: 100% (199/199), 53.08 KiB | 2.12 MiB/s, done.
Resolving deltas: 100% (93/93), done.

$ cd siphash

$ go build
go: cannot find main module, but found .git/config in /tmp/siphash
	to create a module there, run:
	go mod init
```

This adds the go.mod that `go mod init` produces.