### PR TITLE
Simplify switch in amd64 assembler

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/dchest/siphash
+
+go 1.16

--- a/hash128_amd64.s
+++ b/hash128_amd64.s
@@ -68,10 +68,8 @@ loopBody:
 	CMPQ	R10,DI
 	JA	loopBody
 afterLoop:
-	SUBQ	R10,DX
-
-	CMPQ	DX,$0x7
-	JA	afterSwitch
+	ANDL	$7, DX
+	JZ	afterSwitch
 
 	// no support for jump tables
 
@@ -93,10 +91,7 @@ afterLoop:
 	CMPQ	DX,$0x2
 	JE	sw2
 
-	CMPQ	DX,$0x1
-	JE	sw1
-
-	JMP	afterSwitch
+	JMP	sw1
 
 sw7:	MOVBQZX	6(SI)(DI*1),DX
 	SHLQ	$0x30,DX

--- a/hash_amd64.s
+++ b/hash_amd64.s
@@ -59,10 +59,8 @@ loopBody:
 	CMPQ	R10,DI
 	JA	loopBody
 afterLoop:
-	SUBQ	R10,DX
-
-	CMPQ	DX,$0x7
-	JA	afterSwitch
+	ANDL	$7, DX
+	JZ	afterSwitch
 
 	// no support for jump tables
 
@@ -84,10 +82,7 @@ afterLoop:
 	CMPQ	DX,$0x2
 	JE	sw2
 
-	CMPQ	DX,$0x1
-	JE	sw1
-
-	JMP	afterSwitch
+	JMP	sw1
 
 sw7:	MOVBQZX	6(SI)(DI*1),DX
 	SHLQ	$0x30,DX


### PR DESCRIPTION
After the main loop, Hash has to process the remaining 0-7 bytes. The amd64 versions of Hash and Hash128 check whether they have >=8 bytes left. They never do, so they can instead check whether they have zero bytes left by AND'ing len(p) with 7, and skip the whole switch if the result is zero. Then, the check for 1 byte left at the end of the switch can also be skipped.

This gives a tiny performance gain for short inputs. Benchmark results on Linux/Go 1.16:

    name               old speed      new speed      delta
    Hash8-8             511MB/s ± 1%   524MB/s ± 0%  +2.57%  (p=0.000 n=10+10)
    Hash16-8            842MB/s ± 0%   853MB/s ± 0%  +1.31%  (p=0.000 n=9+10)
    Hash40-8           1.36GB/s ± 1%  1.37GB/s ± 1%  +0.81%  (p=0.000 n=10+10)
    Hash64-8           1.59GB/s ± 1%  1.60GB/s ± 0%  +0.63%  (p=0.006 n=10+9)
    Hash128-8          1.87GB/s ± 1%  1.89GB/s ± 0%  +0.75%  (p=0.000 n=9+10)
    Hash1K-8           2.25GB/s ± 0%  2.24GB/s ± 1%    ~     (p=0.447 n=9+10)
    Hash1Kunaligned-8  2.25GB/s ± 1%  2.26GB/s ± 1%  +0.50%  (p=0.003 n=10+10)
    Hash8K-8           2.32GB/s ± 1%  2.32GB/s ± 1%    ~     (p=0.631 n=10+10)
    Hash128_8-8         347MB/s ± 0%   351MB/s ± 0%  +1.39%  (p=0.000 n=9+10)
    Hash128_16-8        599MB/s ± 1%   613MB/s ± 1%  +2.30%  (p=0.000 n=10+10)
    Hash128_40-8       1.07GB/s ± 1%  1.09GB/s ± 1%  +1.11%  (p=0.000 n=9+10)
    Hash128_64-8       1.34GB/s ± 0%  1.35GB/s ± 0%  +0.30%  (p=0.006 n=8+9)
    Hash128_128-8      1.67GB/s ± 1%  1.69GB/s ± 1%  +1.06%  (p=0.000 n=10+10)
    Hash128_1K-8       2.21GB/s ± 1%  2.21GB/s ± 1%    ~     (p=0.356 n=9+10)
    Hash128_8K-8       2.32GB/s ± 1%  2.30GB/s ± 0%  -0.65%  (p=0.004 n=9+9)