### PR TITLE
[WIP] Add generic versions of Hash and Hash128

### DIFF
--- a/blocks.go
+++ b/blocks.go
@@ -1,5 +1,4 @@
 //go:build (!arm && !amd64) || appengine || gccgo
-// +build !arm,!amd64 appengine gccgo
 
 package siphash
 

--- a/blocks_amd64.s
+++ b/blocks_amd64.s
@@ -1,5 +1,4 @@
 //go:build amd64 && !appengine && !gccgo
-// +build amd64,!appengine,!gccgo
 
 #define ROUND(v0, v1, v2, v3) \
 	ADDQ v1, v0; \

--- a/blocks_asm.go
+++ b/blocks_asm.go
@@ -1,5 +1,4 @@
 //go:build arm || (amd64 && !appengine && !gccgo)
-// +build arm amd64,!appengine,!gccgo
 
 // Written in 2012 by Dmitry Chestnykh.
 //

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/dchest/siphash
 
-go 1.16
+go 1.18

--- a/hash.go
+++ b/hash.go
@@ -1,5 +1,4 @@
 //go:build (!arm && !amd64) || appengine || gccgo
-// +build !arm,!amd64 appengine gccgo
 
 // Written in 2012 by Dmitry Chestnykh.
 //
@@ -10,9 +9,9 @@
 
 package siphash
 
-// Hash returns the 64-bit SipHash-2-4 of the given byte slice with two 64-bit
+// HashG returns the 64-bit SipHash-2-4 of the given string or byte slice with two 64-bit
 // parts of 128-bit key: k0 and k1.
-func Hash(k0, k1 uint64, p []byte) uint64 {
+func HashG[T byteseq](k0, k1 uint64, p T) uint64 {
 	// Initialization.
 	v0 := k0 ^ 0x736f6d6570736575
 	v1 := k1 ^ 0x646f72616e646f6d

--- a/hash128.go
+++ b/hash128.go
@@ -1,5 +1,4 @@
 //go:build (!arm && !amd64) || appengine || gccgo
-// +build !arm,!amd64 appengine gccgo
 
 // Written in 2012 by Dmitry Chestnykh.
 // Modifications 2014 for 128-bit hash function by Damian Gryski.
@@ -11,11 +10,11 @@
 
 package siphash
 
-// Hash returns the 128-bit SipHash-2-4 of the given byte slice with two 64-bit
+// Hash128G returns the 128-bit SipHash-2-4 of the given string or byte slice with two 64-bit
 // parts of 128-bit key: k0 and k1.
 //
 // Note that 128-bit SipHash is considered experimental by SipHash authors at this time.
-func Hash128(k0, k1 uint64, p []byte) (uint64, uint64) {
+func Hash128G[T byteseq](k0, k1 uint64, p T) (uint64, uint64) {
 	// Initialization.
 	v0 := k0 ^ 0x736f6d6570736575
 	v1 := k1 ^ 0x646f72616e646f6d

--- a/hash128_amd64.s
+++ b/hash128_amd64.s
@@ -1,5 +1,4 @@
 //go:build amd64 && !appengine && !gccgo
-// +build amd64,!appengine,!gccgo
 
 // This is a translation of the gcc output of FloodyBerry's pure-C public
 // domain siphash implementation at https://github.com/floodyberry/siphash
@@ -11,8 +10,8 @@
 // CX = v2
 // DX = v3
 
-// func Hash128(k0, k1 uint64, b []byte) (r0 uint64, r1 uint64)
-TEXT	·Hash128(SB),4,$0-56
+// func _hash128(k0, k1 uint64, b string) (r0 uint64, r1 uint64)
+TEXT	·_hash128(SB),4,$0-56
 	MOVQ	k0+0(FP),CX
 	MOVQ	$0x736F6D6570736575,R9
 	MOVQ	k1+8(FP),DI
@@ -216,7 +215,7 @@ afterSwitch:
 	XORQ	AX,BX
 	XORQ	DX,BX
 	XORQ	CX,BX
-	MOVQ	BX,ret+40(FP)
+	MOVQ	BX,ret+32(FP)
 
 	// Start the second finalization round
 
@@ -283,6 +282,6 @@ afterSwitch:
 	XORQ	AX,BX
 	XORQ	DX,BX
 	XORQ	CX,BX
-	MOVQ	BX,ret1+48(FP)
+	MOVQ	BX,ret1+40(FP)
 
 	RET

--- a/hash_amd64.s
+++ b/hash_amd64.s
@@ -1,10 +1,9 @@
 //go:build amd64 && !appengine && !gccgo
-// +build amd64,!appengine,!gccgo
 
 // This is a translation of the gcc output of FloodyBerry's pure-C public
 // domain siphash implementation at https://github.com/floodyberry/siphash
-// func Hash(k0, k1 uint64, b []byte) uint64
-TEXT	·Hash(SB),4,$0-48
+// func hash(k0, k1 uint64, b string) uint64
+TEXT	·_hash(SB),4,$0-48
 	MOVQ	k0+0(FP),CX
 	MOVQ	$0x736F6D6570736575,R9
 	MOVQ	k1+8(FP),DI
@@ -193,5 +192,5 @@ afterSwitch:
 	RORQ	$0x20,CX
 	XORQ	DX,AX
 	XORQ	CX,AX
-	MOVQ	AX,ret+40(FP)
+	MOVQ	AX,ret+32(FP)
 	RET

--- a/hash_arm.go
+++ b/hash_arm.go
@@ -1,5 +1,4 @@
 //go:build arm
-// +build arm
 
 package siphash
 

--- a/hash_asm.go
+++ b/hash_asm.go
@@ -1,5 +1,4 @@
 //go:build amd64 && !appengine && !gccgo
-// +build amd64,!appengine,!gccgo
 
 // Written in 2012 by Dmitry Chestnykh.
 //
@@ -12,14 +11,24 @@
 
 package siphash
 
-//go:noescape
+import "unsafe"
 
-// Hash returns the 64-bit SipHash-2-4 of the given byte slice with two 64-bit
+//go:noescape
+func _hash(k0, k1 uint64, b string) uint64
+
+// HashG returns the 64-bit SipHash-2-4 of the given byte slice or string with two 64-bit
 // parts of 128-bit key: k0 and k1.
-func Hash(k0, k1 uint64, b []byte) uint64
+func HashG[T byteseq](k0, k1 uint64, b T) uint64 {
+	// T is string or []byte which can be safely cast to string
+	return _hash(k0, k1, *(*string)(unsafe.Pointer(&b)))
+}
 
 //go:noescape
+func _hash128(k0, k1 uint64, b string) (uint64, uint64)
 
-// Hash128 returns the 128-bit SipHash-2-4 of the given byte slice with two
+// Hash128G returns the 128-bit SipHash-2-4 of the given byte slice or string with two
 // 64-bit parts of 128-bit key: k0 and k1.
-func Hash128(k0, k1 uint64, b []byte) (uint64, uint64)
+func Hash128G[T byteseq](k0, k1 uint64, b T) (uint64, uint64) {
+	// T is string or []byte which can be safely cast to string
+	return _hash128(k0, k1, *(*string)(unsafe.Pointer(&b)))
+}

--- a/hash_compat.go
+++ b/hash_compat.go
@@ -1,0 +1,19 @@
+package siphash
+
+type byteseq interface {
+	string | []byte
+}
+
+// Hash returns the 64-bit SipHash-2-4 of the given byte slice with two 64-bit
+// parts of 128-bit key: k0 and k1.
+func Hash(k0, k1 uint64, p []byte) uint64 {
+	return HashG(k0, k1, p)
+}
+
+// Hash128 returns the 128-bit SipHash-2-4 of the given byte slice with two 64-bit
+// parts of 128-bit key: k0 and k1.
+//
+// Note that 128-bit SipHash is considered experimental by SipHash authors at this time.
+func Hash128(k0, k1 uint64, p []byte) (uint64, uint64) {
+	return Hash128G(k0, k1, p)
+}

--- a/siphash_test.go
+++ b/siphash_test.go
@@ -296,6 +296,12 @@ func TestHash(t *testing.T) {
 		if sum := Hash(k0, k1, in[:i]); sum != ref {
 			t.Errorf(`%d: expected "%x", got "%x"`, i, ref, sum)
 		}
+		if sum := HashG(k0, k1, in[:i]); sum != ref {
+			t.Errorf(`HashG %d: expected "%x", got "%x"`, i, ref, sum)
+		}
+		if sum := HashG(k0, k1, string(in[:i])); sum != ref {
+			t.Errorf(`HashG_string %d: expected "%x", got "%x"`, i, ref, sum)
+		}
 	}
 }
 
@@ -339,6 +345,12 @@ func TestHash128(t *testing.T) {
 		ref1 := binary.LittleEndian.Uint64(goldenRef128[i][8:])
 		if sum0, sum1 := Hash128(k0, k1, in[:i]); sum0 != ref0 || sum1 != ref1 {
 			t.Errorf(`%d: expected "%x, %x", got "%x, %x"`, i, ref0, ref1, sum0, sum1)
+		}
+		if sum0, sum1 := Hash128G(k0, k1, in[:i]); sum0 != ref0 || sum1 != ref1 {
+			t.Errorf(`Hash128G %d: expected "%x, %x", got "%x, %x"`, i, ref0, ref1, sum0, sum1)
+		}
+		if sum0, sum1 := Hash128G(k0, k1, string(in[:i])); sum0 != ref0 || sum1 != ref1 {
+			t.Errorf(`Hash128G_string %d: expected "%x, %x", got "%x, %x"`, i, ref0, ref1, sum0, sum1)
 		}
 	}
 }
@@ -386,6 +398,23 @@ func TestAlign(t *testing.T) {
 		if reshi != want128[i*2+1] {
 			t.Fatalf("Expected %v got %v", want128[i*2+1], reshi)
 		}
+
+		reslo, reshi = Hash128G(k0, k1, d[i:])
+		if reslo != want128[i*2] {
+			t.Fatalf("Hash128G Expected %v got %v", want128[i*2], reslo)
+		}
+		if reshi != want128[i*2+1] {
+			t.Fatalf("Hash128G Expected %v got %v", want128[i*2+1], reshi)
+		}
+
+		reslo, reshi = Hash128G(k0, k1, string(d[i:]))
+		if reslo != want128[i*2] {
+			t.Fatalf("Hash128G_string Expected %v got %v", want128[i*2], reslo)
+		}
+		if reshi != want128[i*2+1] {
+			t.Fatalf("Hash128G_string Expected %v got %v", want128[i*2+1], reshi)
+		}
+
 		dig := newDigest(Size, k[:])
 		dig.Write(d[i:])
 		res = dig.Sum64()
@@ -415,105 +444,105 @@ var (
 func BenchmarkHash8(b *testing.B) {
 	b.SetBytes(8)
 	for i := 0; i < b.N; i++ {
-		Hash(key0, key1, buf[:8])
+		HashG(key0, key1, buf[:8])
 	}
 }
 
 func BenchmarkHash16(b *testing.B) {
 	b.SetBytes(16)
 	for i := 0; i < b.N; i++ {
-		Hash(key0, key1, buf[:16])
+		HashG(key0, key1, buf[:16])
 	}
 }
 
 func BenchmarkHash40(b *testing.B) {
 	b.SetBytes(40)
 	for i := 0; i < b.N; i++ {
-		Hash(key0, key1, buf[:40])
+		HashG(key0, key1, buf[:40])
 	}
 }
 
 func BenchmarkHash64(b *testing.B) {
 	b.SetBytes(64)
 	for i := 0; i < b.N; i++ {
-		Hash(key0, key1, buf[:64])
+		HashG(key0, key1, buf[:64])
 	}
 }
 
 func BenchmarkHash128(b *testing.B) {
 	b.SetBytes(128)
 	for i := 0; i < b.N; i++ {
-		Hash(key0, key1, buf[:128])
+		HashG(key0, key1, buf[:128])
 	}
 }
 
 func BenchmarkHash1K(b *testing.B) {
 	b.SetBytes(1024)
 	for i := 0; i < b.N; i++ {
-		Hash(key0, key1, buf[:1024])
+		HashG(key0, key1, buf[:1024])
 	}
 }
 
 func BenchmarkHash1Kunaligned(b *testing.B) {
 	b.SetBytes(1024)
 	for i := 0; i < b.N; i++ {
-		Hash(key0, key1, buf[1:1025])
+		HashG(key0, key1, buf[1:1025])
 	}
 }
 
 func BenchmarkHash8K(b *testing.B) {
 	b.SetBytes(int64(len(buf)))
 	for i := 0; i < b.N; i++ {
-		Hash(key0, key1, buf)
+		HashG(key0, key1, buf)
 	}
 }
 
 func BenchmarkHash128_8(b *testing.B) {
 	b.SetBytes(8)
 	for i := 0; i < b.N; i++ {
-		Hash128(key0, key1, buf[:8])
+		Hash128G(key0, key1, buf[:8])
 	}
 }
 
 func BenchmarkHash128_16(b *testing.B) {
 	b.SetBytes(16)
 	for i := 0; i < b.N; i++ {
-		Hash128(key0, key1, buf[:16])
+		Hash128G(key0, key1, buf[:16])
 	}
 }
 
 func BenchmarkHash128_40(b *testing.B) {
 	b.SetBytes(40)
 	for i := 0; i < b.N; i++ {
-		Hash128(key0, key1, buf[:40])
+		Hash128G(key0, key1, buf[:40])
 	}
 }
 
 func BenchmarkHash128_64(b *testing.B) {
 	b.SetBytes(64)
 	for i := 0; i < b.N; i++ {
-		Hash128(key0, key1, buf[:64])
+		Hash128G(key0, key1, buf[:64])
 	}
 }
 
 func BenchmarkHash128_128(b *testing.B) {
 	b.SetBytes(128)
 	for i := 0; i < b.N; i++ {
-		Hash128(key0, key1, buf[:128])
+		Hash128G(key0, key1, buf[:128])
 	}
 }
 
 func BenchmarkHash128_1K(b *testing.B) {
 	b.SetBytes(1024)
 	for i := 0; i < b.N; i++ {
-		Hash128(key0, key1, buf[:1024])
+		Hash128G(key0, key1, buf[:1024])
 	}
 }
 
 func BenchmarkHash128_8K(b *testing.B) {
 	b.SetBytes(int64(len(buf)))
 	for i := 0; i < b.N; i++ {
-		Hash128(key0, key1, buf)
+		Hash128G(key0, key1, buf)
 	}
 }
 


### PR DESCRIPTION
New functions can accept `[]byte` or `string`.
Backwards compatibility saved by wrapping new functions.
Assembly functions signature changed a bit to allow simple unsafe cast `[]byte|string` to `string`.